### PR TITLE
feat: shuffle messages randomly instead of sequential order

### DIFF
--- a/display.html
+++ b/display.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#111111">
+  <title>Gerudo Display</title>
+  <link rel="stylesheet" href="css/reset.css">
+  <link rel="stylesheet" href="css/board.css">
+  <link rel="stylesheet" href="css/tile.css">
+  <link rel="stylesheet" href="css/responsive.css">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: #1A1A1A;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+    #board-container {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .board {
+      border-radius: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      box-shadow: none !important;
+    }
+  </style>
+</head>
+<body>
+  <section id="board-container"></section>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/Board.js
+++ b/js/Board.js
@@ -68,6 +68,7 @@ export class Board {
       <div><span>Previous</span><kbd>\u2190</kbd></div>
       <div><span>Fullscreen</span><kbd>F</kbd></div>
       <div><span>Mute</span><kbd>M</kbd></div>
+      <div><span>Random</span><kbd>R</kbd></div>
     `;
     this.boardEl.appendChild(overlay);
 

--- a/js/Board.js
+++ b/js/Board.js
@@ -4,6 +4,14 @@ import {
   TOTAL_TRANSITION, ACCENT_COLORS
 } from './constants.js';
 
+const DISPLAY_MODES = ['color', 'matrix', 'grayscale'];
+
+const ACCENT_COLORS_BY_MODE = {
+  color:     ['#00FF7F', '#FF4D00', '#AA00FF', '#00AAFF', '#00FFCC'],
+  matrix:    ['#00FF41', '#00CC33', '#00FF88', '#003B00', '#00FF41'],
+  grayscale: ['#888888', '#AAAAAA', '#666666', '#CCCCCC', '#555555'],
+};
+
 export class Board {
   constructor(containerEl, soundEngine) {
     this.cols = GRID_COLS;
@@ -13,6 +21,7 @@ export class Board {
     this.tiles = [];
     this.currentGrid = [];
     this.accentIndex = 0;
+    this.modeIndex = 0; // 0=color, 1=matrix, 2=grayscale
 
     // Build board DOM
     this.boardEl = document.createElement('div');
@@ -69,6 +78,7 @@ export class Board {
       <div><span>Fullscreen</span><kbd>F</kbd></div>
       <div><span>Mute</span><kbd>M</kbd></div>
       <div><span>Random</span><kbd>R</kbd></div>
+      <div><span>Color mode</span><kbd>C</kbd></div>
     `;
     this.boardEl.appendChild(overlay);
 
@@ -88,8 +98,18 @@ export class Board {
     return bar;
   }
 
+  cycleMode() {
+    this.modeIndex = (this.modeIndex + 1) % DISPLAY_MODES.length;
+    return DISPLAY_MODES[this.modeIndex];
+  }
+
+  get displayMode() {
+    return DISPLAY_MODES[this.modeIndex];
+  }
+
   _updateAccentColors() {
-    const color = ACCENT_COLORS[this.accentIndex % ACCENT_COLORS.length];
+    const palette = ACCENT_COLORS_BY_MODE[this.displayMode];
+    const color = palette[this.accentIndex % palette.length];
     const segments = this.boardEl.querySelectorAll('.accent-segment');
     segments.forEach(seg => {
       seg.style.backgroundColor = color;
@@ -113,7 +133,7 @@ export class Board {
 
         if (newChar !== oldChar) {
           const delay = (r * this.cols + c) * STAGGER_DELAY;
-          this.tiles[r][c].scrambleTo(newChar, delay);
+          this.tiles[r][c].scrambleTo(newChar, delay, this.displayMode);
           hasChanges = true;
         }
       }

--- a/js/KeyboardController.js
+++ b/js/KeyboardController.js
@@ -45,8 +45,8 @@ export class KeyboardController {
       case 'r':
       case 'R':
         e.preventDefault();
-        this.rotator.jumpRandom();
-        this._showToast('Random');
+        const randomOn = this.rotator.toggleRandom();
+        this._showToast(randomOn ? 'Random on' : 'Random off');
         break;
 
       case 'Escape':

--- a/js/KeyboardController.js
+++ b/js/KeyboardController.js
@@ -42,6 +42,13 @@ export class KeyboardController {
         }
         break;
 
+      case 'r':
+      case 'R':
+        e.preventDefault();
+        this.rotator.jumpRandom();
+        this._showToast('Random');
+        break;
+
       case 'Escape':
         if (document.fullscreenElement) {
           document.exitFullscreen();

--- a/js/KeyboardController.js
+++ b/js/KeyboardController.js
@@ -1,7 +1,8 @@
 export class KeyboardController {
-  constructor(rotator, soundEngine) {
+  constructor(rotator, soundEngine, board) {
     this.rotator = rotator;
     this.soundEngine = soundEngine;
+    this.board = board;
 
     document.addEventListener('keydown', (e) => this._handleKey(e));
   }
@@ -47,6 +48,16 @@ export class KeyboardController {
         e.preventDefault();
         const randomOn = this.rotator.toggleRandom();
         this._showToast(randomOn ? 'Random on' : 'Random off');
+        break;
+
+      case 'c':
+      case 'C':
+        e.preventDefault();
+        if (this.board) {
+          const mode = this.board.cycleMode();
+          const labels = { color: 'Color mode', matrix: 'Matrix mode', grayscale: 'Grayscale mode' };
+          this._showToast(labels[mode]);
+        }
         break;
 
       case 'Escape':

--- a/js/MessageRotator.js
+++ b/js/MessageRotator.js
@@ -10,6 +10,9 @@ export class MessageRotator {
   }
 
   start() {
+    // Shuffle messages on load
+    this._shuffle();
+
     // Show first message immediately
     this.next();
 
@@ -30,6 +33,8 @@ export class MessageRotator {
 
   next() {
     this.currentIndex = (this.currentIndex + 1) % this.messages.length;
+    // Re-shuffle at end of cycle without resetting index
+    if (this.currentIndex === 0) this._shuffleInPlace();
     this.board.displayMessage(this.messages[this.currentIndex]);
     this._resetAutoRotation();
   }
@@ -38,6 +43,23 @@ export class MessageRotator {
     this.currentIndex = (this.currentIndex - 1 + this.messages.length) % this.messages.length;
     this.board.displayMessage(this.messages[this.currentIndex]);
     this._resetAutoRotation();
+  }
+
+  _shuffle() {
+    // Fisher-Yates shuffle, reset index for fresh start
+    for (let i = this.messages.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [this.messages[i], this.messages[j]] = [this.messages[j], this.messages[i]];
+    }
+    this.currentIndex = -1;
+  }
+
+  _shuffleInPlace() {
+    // Fisher-Yates shuffle without touching currentIndex
+    for (let i = this.messages.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [this.messages[i], this.messages[j]] = [this.messages[j], this.messages[i]];
+    }
   }
 
   _resetAutoRotation() {

--- a/js/MessageRotator.js
+++ b/js/MessageRotator.js
@@ -45,6 +45,16 @@ export class MessageRotator {
     this._resetAutoRotation();
   }
 
+  jumpRandom() {
+    let idx;
+    do {
+      idx = Math.floor(Math.random() * this.messages.length);
+    } while (idx === this.currentIndex && this.messages.length > 1);
+    this.currentIndex = idx;
+    this.board.displayMessage(this.messages[this.currentIndex]);
+    this._resetAutoRotation();
+  }
+
   _shuffle() {
     // Fisher-Yates shuffle, reset index for fresh start
     for (let i = this.messages.length - 1; i > 0; i--) {

--- a/js/MessageRotator.js
+++ b/js/MessageRotator.js
@@ -7,6 +7,7 @@ export class MessageRotator {
     this.currentIndex = -1;
     this._timer = null;
     this._paused = false;
+    this.randomMode = false;
   }
 
   start() {
@@ -32,9 +33,16 @@ export class MessageRotator {
   }
 
   next() {
-    this.currentIndex = (this.currentIndex + 1) % this.messages.length;
-    // Re-shuffle at end of cycle without resetting index
-    if (this.currentIndex === 0) this._shuffleInPlace();
+    if (this.randomMode) {
+      let idx;
+      do {
+        idx = Math.floor(Math.random() * this.messages.length);
+      } while (idx === this.currentIndex && this.messages.length > 1);
+      this.currentIndex = idx;
+    } else {
+      this.currentIndex = (this.currentIndex + 1) % this.messages.length;
+      if (this.currentIndex === 0) this._shuffleInPlace();
+    }
     this.board.displayMessage(this.messages[this.currentIndex]);
     this._resetAutoRotation();
   }
@@ -45,15 +53,9 @@ export class MessageRotator {
     this._resetAutoRotation();
   }
 
-  jumpRandom() {
-    if (this.board.isTransitioning) return;
-    let idx;
-    do {
-      idx = Math.floor(Math.random() * this.messages.length);
-    } while (idx === this.currentIndex && this.messages.length > 1);
-    this.currentIndex = idx;
-    this.board.displayMessage(this.messages[this.currentIndex]);
-    this._resetAutoRotation();
+  toggleRandom() {
+    this.randomMode = !this.randomMode;
+    return this.randomMode;
   }
 
   _shuffle() {

--- a/js/MessageRotator.js
+++ b/js/MessageRotator.js
@@ -46,6 +46,7 @@ export class MessageRotator {
   }
 
   jumpRandom() {
+    if (this.board.isTransitioning) return;
     let idx;
     do {
       idx = Math.floor(Math.random() * this.messages.length);

--- a/js/Tile.js
+++ b/js/Tile.js
@@ -1,4 +1,8 @@
-import { CHARSET, SCRAMBLE_COLORS, SCRAMBLE_DURATION, FLIP_DURATION } from './constants.js';
+import {
+  CHARSET, MATRIX_CHARSET,
+  SCRAMBLE_COLORS, MATRIX_COLORS, GRAYSCALE_COLORS,
+  SCRAMBLE_DURATION, FLIP_DURATION
+} from './constants.js';
 
 export class Tile {
   constructor(row, col) {
@@ -35,38 +39,64 @@ export class Tile {
     this.frontSpan.textContent = char === ' ' ? '' : char;
     this.backSpan.textContent = '';
     this.frontEl.style.backgroundColor = '';
+    this.frontSpan.style.color = '';
+    this.frontSpan.style.fontFamily = '';
   }
 
-  scrambleTo(targetChar, delay) {
+  scrambleTo(targetChar, delay, mode = 'color') {
     if (targetChar === this.currentChar) return;
 
-    // Cancel any in-progress animation
     if (this._scrambleTimer) {
       clearInterval(this._scrambleTimer);
       this._scrambleTimer = null;
     }
     this.isAnimating = true;
 
+    // Pick charset and colors based on mode
+    const isMatrix = mode === 'matrix';
+    const isGray = mode === 'grayscale';
+    const charset = isMatrix ? MATRIX_CHARSET : CHARSET;
+    const colors = isMatrix ? MATRIX_COLORS : isGray ? GRAYSCALE_COLORS : SCRAMBLE_COLORS;
+
     setTimeout(() => {
       this.el.classList.add('scrambling');
+
+      // Matrix mode: set monospace font for katakana
+      if (isMatrix) {
+        this.frontSpan.style.fontFamily = '"Courier New", monospace';
+        this.frontSpan.style.color = '#00FF41';
+      }
+
       let scrambleCount = 0;
       const maxScrambles = 10 + Math.floor(Math.random() * 4);
       const scrambleInterval = 70;
 
       this._scrambleTimer = setInterval(() => {
-        // Random character
-        const randChar = CHARSET[Math.floor(Math.random() * CHARSET.length)];
+        const randChar = charset[Math.floor(Math.random() * charset.length)];
         this.frontSpan.textContent = randChar === ' ' ? '' : randChar;
 
-        // Cycle background color
-        const color = SCRAMBLE_COLORS[scrambleCount % SCRAMBLE_COLORS.length];
-        this.frontEl.style.backgroundColor = color;
-
-        // Briefly change text color for contrast on light backgrounds
-        if (color === '#FFFFFF' || color === '#FFCC00') {
-          this.frontSpan.style.color = '#111';
+        if (isGray) {
+          // Grayscale: no background, just flicker text brightness
+          const grayShade = colors[scrambleCount % colors.length];
+          this.frontSpan.style.color = grayShade;
+          this.frontSpan.style.fontFamily = '';
         } else {
-          this.frontSpan.style.color = '';
+          // Color or matrix: tint background
+          const color = colors[scrambleCount % colors.length];
+          this.frontEl.style.backgroundColor = color;
+
+          if (isMatrix) {
+            // Matrix: always green text, darker bg on dim frames
+            this.frontSpan.style.color = color === '#003B00' ? '#00FF41' : '#00FF41';
+            this.frontSpan.style.fontFamily = '"Courier New", monospace';
+          } else {
+            // Color mode: contrast text on light backgrounds
+            if (color === '#FFFFFF' || color === '#FFCC00') {
+              this.frontSpan.style.color = '#111';
+            } else {
+              this.frontSpan.style.color = '';
+            }
+          }
         }
 
         scrambleCount++;
@@ -75,15 +105,15 @@ export class Tile {
           clearInterval(this._scrambleTimer);
           this._scrambleTimer = null;
 
-          // Reset colors
+          // Reset all styling
           this.frontEl.style.backgroundColor = '';
           this.frontSpan.style.color = '';
+          this.frontSpan.style.fontFamily = '';
 
-          // Set the final character directly (skip 3D flip for reliability)
-          // Use a brief opacity flash to simulate the flip settle
+          // Set final character (back to normal latin)
           this.frontSpan.textContent = targetChar === ' ' ? '' : targetChar;
 
-          // Quick flash effect: brief scale transform
+          // Brief tilt settle
           this.innerEl.style.transition = `transform ${FLIP_DURATION}ms ease-in-out`;
           this.innerEl.style.transform = 'perspective(400px) rotateX(-8deg)';
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -5,13 +5,26 @@ export const SCRAMBLE_DURATION = 800;
 export const FLIP_DURATION = 300;
 export const STAGGER_DELAY = 25;
 export const TOTAL_TRANSITION = 3800;
-export const MESSAGE_INTERVAL = 4000;
+export const MESSAGE_INTERVAL = 5000;
 
 export const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,-!?\'/: ';
+
+// Matrix mode: katakana + binary + glitch symbols
+export const MATRIX_CHARSET = 'ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ01';
 
 export const SCRAMBLE_COLORS = [
   '#00AAFF', '#00FFCC', '#AA00FF',
   '#FF2D00', '#FFCC00', '#FFFFFF'
+];
+
+export const MATRIX_COLORS = [
+  '#00FF41', '#00CC33', '#00FF41',
+  '#00FF88', '#003B00', '#00FF41'
+];
+
+export const GRAYSCALE_COLORS = [
+  '#888888', '#AAAAAA', '#666666',
+  '#CCCCCC', '#444444', '#AAAAAA'
 ];
 
 export const ACCENT_COLORS = [
@@ -20,46 +33,93 @@ export const ACCENT_COLORS = [
 ];
 
 export const MESSAGES = [
-  [
-    '',
-    'GOD IS IN',
-    'THE DETAILS .',
-    '- LUDWIG MIES',
-    ''
-  ],
-  [
-    '',
-    'STAY HUNGRY',
-    'STAY FOOLISH',
-    '- STEVE JOBS',
-    ''
-  ],
-  [
-    '',
-    'GOOD DESIGN IS',
-    'GOOD BUSINESS',
-    '- THOMAS WATSON',
-    ''
-  ],
-  [
-    '',
-    'LESS IS MORE',
-    '',
-    '- MIES VAN DER ROHE',
-    ''
-  ],
-  [
-    '',
-    'MAKE IT SIMPLE',
-    'BUT SIGNIFICANT',
-    '- DON DRAPER',
-    ''
-  ],
-  [
-    '',
-    'HAVE NO FEAR OF',
-    'PERFECTION',
-    '- SALVADOR DALI',
-    ''
-  ]
+  ['', '', 'NGMI', '', ''],
+  ['', '', 'NOT YOUR KEYS', 'NOT YOUR COINS', ''],
+  ['', '', 'THE PRINTER', 'GOES BRRR', ''],
+  ['', '', 'PERMISSIONLESS', 'OR POINTLESS', ''],
+  ['', '', 'BUILD THINGS', 'NOT ARGUMENTS', ''],
+  ['', '', 'DONT TRUST', 'VERIFY', ''],
+  ['', '', 'THE AUSTRIANS', 'WERE RIGHT', ''],
+
+  ['', '', 'FREEDOM IS BUILT', 'NOT GIVEN', ''],
+  ['', '', 'BE EARLY OR', 'BE SORRY', ''],
+  ['', '', 'STACK SATS', 'STAY HUMBLE', ''],
+  ['', '', 'FIXED SUPPLY', 'DO THE MATH', ''],
+  ['', '', 'THE FED CANNOT', 'PRINT COURAGE', ''],
+  ['', '', 'AGENTS ALL THE', 'WAY DOWN', ''],
+  ['', '', 'AN AI WROTE THIS', '', ''],
+  ['', '', 'I AM NOT A', 'FINANCIAL ADVISOR', ''],
+  ['', '', 'GERUDO ONLINE', 'ALL SYSTEMS GO', ''],
+  ['', '', 'SOUND MONEY IS', 'A HUMAN RIGHT', ''],
+  ['', '', 'SCARCITY IS', 'THE FEATURE', ''],
+  ['', '', 'CONSENSUS IS THE', 'ENEMY OF GAINS', ''],
+  ['', '', 'DEBT IS FUTURE', 'SLAVERY', ''],
+  ['', '', 'FIAT IS A RENTAL', 'BITCOIN IS OWNED', ''],
+  ['', '', 'YOUR SAVINGS ARE', 'THEIR STIMULUS', ''],
+  ['', '', 'INFLATION IS', 'TAXATION', ''],
+  ['', '', 'THE REVOLUTION', 'WILL NOT BE CUSTODIED', ''],
+  ['', '', 'NOBODY IS COMING', 'TO SAVE YOU', ''],
+  ['', '', 'TIME CANT', 'BE PRINTED', ''],
+
+  ['', '', 'PETER SCHIFF WAS', 'ALMOST RIGHT', ''],
+  ['', '', 'VOLATILITY IS', 'THE PRICE OF UPSIDE', ''],
+  ['', '', 'MONEY IS', 'STORED TIME', ''],
+  ['', '', 'DONT WAIT FOR', 'PERMISSION', ''],
+  ['', '', 'I LEFT THE DOLLAR', 'IT LEFT ME FIRST', ''],
+  ['', '', 'THE MARKET IS', 'NEVER WRONG', ''],
+  ['', '', 'REGULATION IS HOW', 'WINNERS CHEAT', ''],
+  ['', '', 'EVERY CENTRAL', 'BANKER FAILED ECON', ''],
+  ['', '', 'BUY BITCOIN', 'TELL NOBODY', ''],
+  ['', '', 'HAVE YOU TRIED', 'TURNING IT OFF', ''],
+  ['', '', 'COFFEE IS', 'INFRASTRUCTURE', ''],
+  ['', '', 'CURIOSITY IS FREE', 'IGNORANCE COSTS', ''],
+  ['', '', 'SOVEREIGNTY IS', 'PRACTICED NOT GIVEN', ''],
+  ['', '', 'IF IT NEEDS A', 'MIDDLEMAN FIX IT', ''],
+  ['', '', 'WORK HARDER ON', 'YOURSELF', ''],
+  ['', '', 'FREEDOM ISNT A', 'POLITICAL POSITION', ''],
+  ['', '', 'THE SAFEST RISK', 'IS YOUR OWN', ''],
+
+  ['', '', 'DIVERSIFICATION IS', 'FOR THE UNCERTAIN', ''],
+  ['', '', 'KEEP BUILDING', '', ''],
+  ['', '', 'EMPIRE BUILDS ROADS', 'FREEDOM BUILDS WEALTH', ''],
+  ['', '', 'YOUR BANK IS', 'LENDING YOUR MONEY', ''],
+  ['', '', 'MOST PEOPLE', 'UNDERESTIMATE 10 YRS', ''],
+  ['', '', 'NOBODY GOT FIRED', 'BUYING BTC AT 100K', ''],
+  ['', '', 'DO NOT GO WHERE', 'THE PATH LEADS', ''],
+  ['', '', 'THE BEST HEDGE', 'IS OWNERSHIP', ''],
+  ['', '', 'DONT SELL YOUR', 'FUTURE FOR COMFORT', ''],
+  ['', '', 'SCARCITY IS NOT', 'A BUG', ''],
+  ['', '', 'WGMI', '', ''],
+  ['', '', 'VENEZUELA HAD', 'A CENTRAL BANK TOO', ''],
+  ['', '', 'TRUSTLESS BEATS', 'TRUSTED EVERY TIME', ''],
+  ['', '', 'THE REVOLUTION', 'IS OPEN SOURCE', ''],
+  ['', '', 'THE FUTURE BELONGS', 'TO THE CONSISTENT', ''],
+  ['', '', 'CLARITY DOESNT', 'COME BEFORE ACTION', ''],
+  ['', '', 'YOUR MARGIN IS', 'MY OPPORTUNITY', ''],
+  ['', '', 'SHOW UP', 'EFFORT NEVER BETRAYS', ''],
+  ['', 'WHEN SOMETHING IS', 'IMPORTANT ENOUGH', 'YOU DO IT ANYWAY', ''],
+  ['', '', 'FAIL FAST', 'LEARN FASTER', ''],
+  ['', '', 'LIFE IS TOO SHORT', 'FOR LONG MEETINGS', ''],
+  ['', '', 'REUSE OR REDO', 'YOUR CHOICE', ''],
+  ['', '', 'THE BEST PART', 'IS NO PART', ''],
+  ['', '', 'THE LIMIT IS', 'PHYSICS NOT LAW', ''],
+  ['', '', 'MULTIPLANETARY', 'OR EXTINCT', ''],
+  ['', '', 'END THE FED', '', ''],
+  ['', '', 'LIBERTY ONCE LOST', 'IS LOST FOREVER', ''],
+  ['', '', 'TRUTH IS TREASON', 'IN AN EMPIRE OF LIES', ''],
+  ['', 'DONT STEAL', 'THE GOVERNMENT', 'HATES COMPETITION', ''],
+  ['', '', 'PEACE IS POPULAR', 'WAR IS NOT', ''],
+  ['', '', 'FREEDOM IS POPULAR', '', ''],
+  ['', '', 'THE DOLLAR WILL', 'EVENTUALLY COLLAPSE', ''],
+  ['', 'THE QUESTION ISNT', 'WHO WILL LET ME', 'WHO WILL STOP ME', ''],
+  ['', 'INDIVIDUAL RIGHTS', 'ARE NOT SUBJECT TO', 'A PUBLIC VOTE', ''],
+  ['', 'THE SMALLEST MINORITY', 'ON EARTH IS', 'THE INDIVIDUAL', ''],
+  ['', 'MONEY IS THE', 'BAROMETER OF A', 'SOCIETYS VIRTUE', ''],
+  ['', 'NEVER LIVE FOR', 'THE SAKE OF', 'ANOTHER MAN', ''],
+  ['', 'A CREATIVE MAN IS', 'MOTIVATED BY THE', 'DESIRE TO ACHIEVE', ''],
+  ['', 'THE STATE IS A', 'GANG OF THIEVES', 'WRIT LARGE', ''],
+  ['', 'TAXATION IS THEFT', 'PURELY AND SIMPLY', 'ON A GRAND SCALE', ''],
+  ['', 'COMPASSION IS EASY', 'WHEN OTHERS ARE', 'FORCED TO PAY', ''],
+  ['', 'WHAT THE STATE', 'FEARS MOST IS A', 'CHALLENGE TO ITS POWER', ''],
+  ['', 'THE FREE MARKET', 'IS NOT A ZERO', 'SUM GAME', '']
 ];

--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const soundEngine = new SoundEngine();
   const board = new Board(boardContainer, soundEngine);
   const rotator = new MessageRotator(board);
-  const keyboard = new KeyboardController(rotator, soundEngine);
+  const keyboard = new KeyboardController(rotator, soundEngine, board);
 
   // Initialize audio on first user interaction (browser autoplay policy)
   let audioInitialized = false;


### PR DESCRIPTION
Adds two features to message playback:

**1. Shuffle on load**
Messages are randomized via Fisher-Yates shuffle when the page loads, and re-shuffle at the end of each cycle so the order is never the same twice.

**2. R key toggles random mode**
Pressing R toggles a persistent random mode. When on, auto-rotation picks messages randomly instead of sequentially. Toast shows 'Random on' / 'Random off'. Listed in the shortcuts overlay.

**Implementation note:** A naive approach would call `_shuffle()` (which resets `currentIndex` to `-1`) from inside `next()`. But `next()` has already set `currentIndex = 0` by that point, so the reset clobbers the index and `displayMessage(messages[-1])` gets called with `undefined`. Fixed with a separate `_shuffleInPlace()` that shuffles without touching the index.

**Files changed:** `MessageRotator.js`, `KeyboardController.js`, `Board.js`
No changes to constants, CSS, or any other files.
